### PR TITLE
Using notification id as optinal parameter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,11 @@ fn main() {
                                           .long("icon")
                                           .takes_value(true))
 
+                                    .arg( Arg::with_name("ID")
+                                          .help("Specifies the ID and overrides existing notifications with the same ID.")
+                                          .long("id")
+                                          .takes_value(true))
+
                                     .arg( Arg::with_name("hint")
                                           .help("Specifies basic extra data to pass. Valid types are int, double, string and byte. Pattern: TYPE:NAME:VALUE")
                                           .short("h")
@@ -183,6 +188,11 @@ fn main() {
                     notification.urgency(notify_rust::NotificationUrgency::Critical)
                 }
             };
+        }
+
+        if let Some(id) = matches.value_of("ID") {
+            let id = id.parse::<u32>().expect("The id has to be an unsigned integer");
+            notification.id(id);
         }
 
         if let Some(hint) = matches.value_of("hint") {


### PR DESCRIPTION
having a notification that updates like a `volume indicator` the possibility to overwrite existing notifications is crucial.

[notify_rust](https://www.hoodie.de/notify-rust/notify_rust/struct.Notification.html#method.id) already implements this functionality with an `id`.

This functionality is provided by `dunstify`. 
However, `notify-send` and `toastify` lack of this feature so far, even tho it is trivial to implement. 